### PR TITLE
Add CSS to fix Mermaid SVG bug

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -581,3 +581,6 @@ img.centered {
   margin-left: auto;
   margin-right: auto;
 }
+
+/* Fix for Mermaid SVG bug */
+.mermaid svg { height: auto; }


### PR DESCRIPTION
Large graphs render in Mermaid with excessive whitespace above
and below. This was previously fixed
in https://github.com/mermaid-js/mermaid/pull/2312 but later
reverted with no explaintion in
https://github.com/mermaid-js/mermaid/commit/38ef0611753fcc1e

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>